### PR TITLE
Fix lockfile bug in update script

### DIFF
--- a/scripts/update_videos.sh
+++ b/scripts/update_videos.sh
@@ -21,6 +21,11 @@ if [ ! -f "$URL_FILE" ]; then
 fi
 
 touch "$LOCK_FILE"
+# Ensure lock file is removed on exit or error
+cleanup() {
+  rm -f "$LOCK_FILE"
+}
+trap cleanup EXIT
 cd "$VIDEO_DIR"
 echo "Clearing old videos..."
 rm -f *.mp4
@@ -38,5 +43,5 @@ chmod 644 "$VIDEO_DIR"/*.mp4
 pkill mpv
 
 echo "Done!"
-rm -f "$LOCK_FILE"
+
 


### PR DESCRIPTION
## Summary
- prevent stale `updating.lock` by setting a cleanup trap in `update_videos.sh`

## Testing
- `bash -n scripts/update_videos.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e668036e4832ca5cab9d35af6c8f6